### PR TITLE
Code Cleanup

### DIFF
--- a/mlox/mlox.py
+++ b/mlox/mlox.py
@@ -77,9 +77,6 @@ def command_line_mode(args):
             my_loadorder.get_data_files()
         else:
             my_loadorder.get_active_plugins()
-            if my_loadorder.order == []:
-                logging.warn("No active plugins, defaulting to all plugins in Data Files directory.")
-                my_loadorder.get_data_files()
         process_load_order(my_loadorder, args)
 
 def process_load_order(a_loadorder, args):

--- a/mlox/mlox.py
+++ b/mlox/mlox.py
@@ -236,8 +236,8 @@ if __name__ == "__main__":
     # Check Python version
     logging.debug(version.version_info())
     pyversion = sys.version[:3]
-    if float(pyversion) < 2.5:
-        logging.error("This program requires at least Python version 2.5.")
+    if float(pyversion) < 3:
+        logging.error("This program requires at least Python version 3.")
         sys.exit(1)
 
 

--- a/mlox/modules/fileFinder.py
+++ b/mlox/modules/fileFinder.py
@@ -18,6 +18,7 @@ import logging
 
 file_logger = logging.getLogger('mlox.fileFinder')
 
+
 class caseless_filenames:
 
     def __init__(self):

--- a/mlox/modules/fileFinder.py
+++ b/mlox/modules/fileFinder.py
@@ -141,18 +141,18 @@ def find_game_dirs():
     if gamedir != None:
         game = "Morrowind"
         list_file = gamedir.find_path("Morrowind.ini")
-        datadir = caseless_dirlist(gamedir.find_path("Data Files"))
+        datadir = gamedir.find_path("Data Files")
     else:
         gamedir = cwd.find_parent_dir("Oblivion.ini")
         if gamedir != None:
             game = "Oblivion"
             list_file = _get_Oblivion_plugins_file()
-            datadir = caseless_dirlist(gamedir.find_path("Data"))
+            datadir = gamedir.find_path("Data")
         else:
             # Not running under a game directory, so we're probably testing
             # assume plugins live in current directory.
-            datadir = caseless_dirlist("..")
+            datadir = os.path.abspath("..")
     file_logger.debug("Found Game:  {0}".format(game))
     file_logger.debug("Plugins file at:  {0}".format(list_file))
-    file_logger.debug("Data Files at: {0}".format(datadir.dirpath()))
+    file_logger.debug("Data Files at: {0}".format(datadir))
     return (game,list_file,datadir)

--- a/mlox/modules/loadOrder.py
+++ b/mlox/modules/loadOrder.py
@@ -183,7 +183,7 @@ class loadorder:
         """Explain why a mod is in it's current position"""
         original_graph = self.graph
 
-        parser = ruleParser.rule_parser(self.order, fileFinder.caseless_dirlist(self.datadir), self.caseless)
+        parser = ruleParser.rule_parser(self.order, self.datadir, self.caseless)
         if os.path.exists(user_file):
             parser.read_rules(user_file)
         parser.read_rules(base_file)
@@ -212,7 +212,7 @@ class loadorder:
 
         # read rules from various sources, and add orderings to graph
         # if any subsequent rule causes a cycle in the current graph, it is discarded
-        parser = ruleParser.rule_parser(self.order, fileFinder.caseless_dirlist(self.datadir), self.caseless)
+        parser = ruleParser.rule_parser(self.order, self.datadir, self.caseless)
         if os.path.exists(user_file):
             parser.read_rules(user_file, progress)
         if not parser.read_rules(base_file, progress):

--- a/mlox/modules/loadOrder.py
+++ b/mlox/modules/loadOrder.py
@@ -257,6 +257,7 @@ class loadorder:
         return parser.get_messages()
 
     def write_new_order(self):
+        """Write/save the new order to the directory and config file."""
         if not isinstance(self.new_order,list) or self.new_order == []:
             order_logger.error("Not saving blank load order.")
             return False

--- a/mlox/modules/loadOrder.py
+++ b/mlox/modules/loadOrder.py
@@ -9,7 +9,7 @@ from .resources import base_file, user_file
 old_loadorder_output = "current_loadorder.out"
 new_loadorder_output = "mlox_new_loadorder.out"
 
-order_logger = logging.getLogger('mlox.loadorder')
+order_logger = logging.getLogger('mlox.loadOrder')
 
 class loadorder:
     """Class for reading plugin mod times (load order), and updating them based on rules"""
@@ -213,7 +213,6 @@ class loadorder:
         for p in self.get_original_order():
             order_logger.debug("  " + p)
 
-
         # read rules from various sources, and add orderings to graph
         # if any subsequent rule causes a cycle in the current graph, it is discarded
         parser = ruleParser.rule_parser(self.order, self.datadir, self.caseless)
@@ -268,7 +267,7 @@ class loadorder:
             if configHandler.configHandler(self.plugin_file,self.game_type).write(self.new_order):
                 self.is_sorted = True
 
-        if self.is_sorted != True:
+        if not self.is_sorted:
             order_logger.error("Unable to save new load order.")
             return False
         return True

--- a/mlox/modules/loadOrder.py
+++ b/mlox/modules/loadOrder.py
@@ -17,7 +17,6 @@ class loadorder:
         # order is the list of plugins in Data Files, ordered by mtime
         self.order = []                    # the load order
         self.new_order = []                # the new load order
-        self.graph = pluggraph.pluggraph()
         self.is_sorted = False
         self.caseless = fileFinder.caseless_filenames()
 
@@ -225,15 +224,14 @@ class loadorder:
             self.new_order = []
             return False
 
-        # now do the topological sort of all known plugins (rules + load order)
-        self.graph = parser.get_graph()
-        self.add_current_order(self.graph)    # tertiary order "pseudo-rules" from current load order
-        sorted = self.graph.topo_sort()
+        # Convert the graph into a sorted list of all plugins (rules + load order)
+        plugin_graph = parser.get_graph()
+        self.add_current_order(plugin_graph)    # tertiary order "pseudo-rules" from current load order
+        sorted_plugins = plugin_graph.topo_sort()
 
-        # the "sorted" list will be a superset of all known plugin files,
-        # including those in our Data Files directory.
-        # but we only want to update plugins that are in our current "Data Files"
-        sorted_datafiles = [f for f in sorted if f in self.order]
+        # The "sorted" list will be a superset of all known plugin files,
+        # but we only care about active plugins.
+        sorted_datafiles = [f for f in sorted_plugins if f in self.order]
         (esm_files, esp_files) = configHandler.partition_esps_and_esms(sorted_datafiles)
         new_order_cname = [p for p in esm_files + esp_files]
         self.new_order = [self.caseless.truename(p) for p in new_order_cname]

--- a/mlox/modules/loadOrder.py
+++ b/mlox/modules/loadOrder.py
@@ -1,10 +1,10 @@
 import os
 import logging
-import modules.fileFinder as fileFinder
-import modules.pluggraph as pluggraph
-import modules.configHandler as configHandler
-import modules.ruleParser as ruleParser
-from modules.resources import base_file, user_file
+from . import fileFinder
+from . import pluggraph
+from . import ruleParser
+from . import configHandler
+from .resources import base_file, user_file
 
 old_loadorder_output = "current_loadorder.out"
 new_loadorder_output = "mlox_new_loadorder.out"

--- a/mlox/modules/loadOrder.py
+++ b/mlox/modules/loadOrder.py
@@ -31,7 +31,12 @@ class loadorder:
         self.game_type, self.plugin_file, self.datadir = fileFinder.find_game_dirs()
 
     def get_active_plugins(self):
-        """Get the active list of plugins from the game configuration. Updates self.active and self.order."""
+        """
+        Get the active list of plugins from the game configuration.
+
+        "Active Plugins" are plugins that are both in the Data Files directory and in Morrowind.ini
+        Updates self.active and self.order
+        """
         self.is_sorted = False
         if self.plugin_file == None:
             order_logger.warning("No game configuration file was found!\nAre you sure you're running mlox in or under your game directory?")
@@ -54,7 +59,11 @@ class loadorder:
         self.origin = "Active Plugins"
 
     def get_data_files(self):
-        """Get the load order from the data files directory. Updates self.active and self.order."""
+        """
+        Get the load order from the data files directory.
+
+        Updates self.active and self.order
+        """
         self.is_sorted = False
         self.order = configHandler.dataDirHandler(self.datadir.dirpath()).read()
 
@@ -75,9 +84,12 @@ class loadorder:
         return out
 
     def read_from_file(self, fromfile):
-        """Get the load order by reading an input file.
+        """
+        Get the load order by reading an input file.
+
         Clears self.game_type and self.datadir.
-        Updates self.plugin_file, self.active, and self.order."""
+        Updates self.plugin_file, self.active, and self.order
+        """
         self.is_sorted = False
         self.game_type = None
         self.datadir = None         #This tells the parser to not worry about things like [SIZE] checks, or trying to read the plugin descriptions
@@ -177,7 +189,7 @@ class loadorder:
         return formatted
 
     def explain(self,plugin_name,base_only = False):
-        """Expalin why a mod is in it's current position"""
+        """Explain why a mod is in it's current position"""
         original_graph = self.graph
         self.graph = pluggraph.pluggraph()
 

--- a/mlox/modules/loadOrder.py
+++ b/mlox/modules/loadOrder.py
@@ -1,6 +1,4 @@
 import os
-import sys
-import io
 import logging
 import modules.fileFinder as fileFinder
 import modules.pluggraph as pluggraph
@@ -193,7 +191,7 @@ class loadorder:
         original_graph = self.graph
         self.graph = pluggraph.pluggraph()
 
-        parser = ruleParser.rule_parser(self.active, self.graph, self.datadir,io.StringIO(),self.caseless)
+        parser = ruleParser.rule_parser(self.active, self.graph, self.datadir,self.caseless)
         if os.path.exists(user_file):
             parser.read_rules(user_file)
         parser.read_rules(base_file)
@@ -210,7 +208,6 @@ class loadorder:
         Update the load order based on input rules.
         Returns the parser's recommendations on success, or False if something went wrong.
         """
-        parser_out_stream = io.StringIO()
         self.is_sorted = False
         self.graph = pluggraph.pluggraph()
         if self.order == []:
@@ -223,7 +220,7 @@ class loadorder:
 
         # read rules from various sources, and add orderings to graph
         # if any subsequent rule causes a cycle in the current graph, it is discarded
-        parser = ruleParser.rule_parser(self.active, self.graph, self.datadir,parser_out_stream,self.caseless)
+        parser = ruleParser.rule_parser(self.active, self.graph, self.datadir,self.caseless)
         if os.path.exists(user_file):
             parser.read_rules(user_file, progress)
         if not parser.read_rules(base_file, progress):
@@ -261,7 +258,7 @@ class loadorder:
             # save the load orders to file for future reference
             self.save_order(old_loadorder_output, [self.caseless.truename(p) for p in self.order], "current")
             self.save_order(new_loadorder_output, self.new_order, "mlox sorted")
-        return parser_out_stream.getvalue()
+        return parser.get_messages()
 
     def write_new_order(self):
         if not isinstance(self.new_order,list) or self.new_order == []:

--- a/mlox/modules/loadOrder.py
+++ b/mlox/modules/loadOrder.py
@@ -182,12 +182,12 @@ class loadorder:
     def explain(self,plugin_name,base_only = False):
         """Explain why a mod is in it's current position"""
         original_graph = self.graph
-        self.graph = pluggraph.pluggraph()
 
-        parser = ruleParser.rule_parser(self.order, self.graph, self.datadir,self.caseless)
+        parser = ruleParser.rule_parser(self.order, self.datadir,self.caseless)
         if os.path.exists(user_file):
             parser.read_rules(user_file)
         parser.read_rules(base_file)
+        self.graph = parser.get_graph()
 
         if not base_only:
             self.add_current_order() # tertiary order "pseudo-rules" from current load order
@@ -202,7 +202,6 @@ class loadorder:
         Returns the parser's recommendations on success, or False if something went wrong.
         """
         self.is_sorted = False
-        self.graph = pluggraph.pluggraph()
         if self.order == []:
             order_logger.error("No plugins detected!\nmlox needs to run somewhere under where the game is installed.")
             return False
@@ -213,7 +212,7 @@ class loadorder:
 
         # read rules from various sources, and add orderings to graph
         # if any subsequent rule causes a cycle in the current graph, it is discarded
-        parser = ruleParser.rule_parser(self.order, self.graph, self.datadir,self.caseless)
+        parser = ruleParser.rule_parser(self.order, self.datadir,self.caseless)
         if os.path.exists(user_file):
             parser.read_rules(user_file, progress)
         if not parser.read_rules(base_file, progress):
@@ -222,7 +221,8 @@ class loadorder:
             return False
 
         # now do the topological sort of all known plugins (rules + load order)
-        self.add_current_order() # tertiary order "pseudo-rules" from current load order
+        self.graph = parser.get_graph()
+        self.add_current_order()    # tertiary order "pseudo-rules" from current load order
         sorted = self.graph.topo_sort()
 
         # the "sorted" list will be a superset of all known plugin files,

--- a/mlox/modules/loadOrder.py
+++ b/mlox/modules/loadOrder.py
@@ -40,7 +40,7 @@ class loadorder:
 
         # Get all the plugins
         configFiles = configHandler.configHandler(self.plugin_file,self.game_type).read()
-        dirFiles = configHandler.dataDirHandler(self.datadir.dirpath()).read()
+        dirFiles = configHandler.dataDirHandler(self.datadir).read()
 
         # Remove plugins not in the data directory (and correct capitalization)
         configFiles = list(map(str.lower, configFiles))
@@ -61,12 +61,12 @@ class loadorder:
         Updates self.order
         """
         self.is_sorted = False
-        self.order = configHandler.dataDirHandler(self.datadir.dirpath()).read()
+        self.order = configHandler.dataDirHandler(self.datadir).read()
 
         #Convert the files to lowercase, while storing them in a dict
         self.order = list(map(self.caseless.cname,self.order))
 
-        order_logger.info("Found {0} plugins in: \"{1}\"".format(len(self.order), self.datadir.dirpath()))
+        order_logger.info("Found {0} plugins in: \"{1}\"".format(len(self.order), self.datadir))
 
     def read_from_file(self, fromfile):
         """
@@ -94,7 +94,7 @@ class loadorder:
         """List the versions of all plugins in the current load order"""
         out = "{0:20} {1:20} {2}\n".format("Name", "Description", "Plugin Name")
         for p in self.order:
-            (file_ver, desc_ver) = ruleParser.get_version(p,self.datadir)
+            (file_ver, desc_ver) = ruleParser.get_version(p, self.datadir)
             out += "{0:20} {1:20} {2}\n".format(str(file_ver), str(desc_ver), self.caseless.truename(p))
         return out
 
@@ -183,7 +183,7 @@ class loadorder:
         """Explain why a mod is in it's current position"""
         original_graph = self.graph
 
-        parser = ruleParser.rule_parser(self.order, self.datadir,self.caseless)
+        parser = ruleParser.rule_parser(self.order, fileFinder.caseless_dirlist(self.datadir), self.caseless)
         if os.path.exists(user_file):
             parser.read_rules(user_file)
         parser.read_rules(base_file)
@@ -212,7 +212,7 @@ class loadorder:
 
         # read rules from various sources, and add orderings to graph
         # if any subsequent rule causes a cycle in the current graph, it is discarded
-        parser = ruleParser.rule_parser(self.order, self.datadir,self.caseless)
+        parser = ruleParser.rule_parser(self.order, fileFinder.caseless_dirlist(self.datadir), self.caseless)
         if os.path.exists(user_file):
             parser.read_rules(user_file, progress)
         if not parser.read_rules(base_file, progress):
@@ -257,8 +257,8 @@ class loadorder:
         if not isinstance(self.new_order,list) or self.new_order == []:
             order_logger.error("Not saving blank load order.")
             return False
-        if isinstance(self.datadir,fileFinder.caseless_dirlist):
-            if configHandler.dataDirHandler(self.datadir.dirpath()).write(self.new_order):
+        if self.datadir:
+            if configHandler.dataDirHandler(self.datadir).write(self.new_order):
                 self.is_sorted = True
         if isinstance(self.plugin_file,str):
             if configHandler.configHandler(self.plugin_file,self.game_type).write(self.new_order):

--- a/mlox/modules/loadOrder.py
+++ b/mlox/modules/loadOrder.py
@@ -192,12 +192,12 @@ class loadorder:
         if os.path.exists(user_file):
             parser.read_rules(user_file)
         parser.read_rules(base_file)
-        graph = parser.get_graph()
+        plugin_graph = parser.get_graph()
 
         if not base_only:
-            self.add_current_order(graph) # tertiary order "pseudo-rules" from current load order
+            self.add_current_order(plugin_graph) # tertiary order "pseudo-rules" from current load order
 
-        output = graph.explain(plugin_name, self.order)
+        output = plugin_graph.explain(plugin_name, self.order)
         return output
 
     def update(self,progress = None):

--- a/mlox/modules/loadOrder.py
+++ b/mlox/modules/loadOrder.py
@@ -17,13 +17,13 @@ class loadorder:
         # order is the list of plugins in Data Files, ordered by mtime
         self.order = []                    # the load order
         self.new_order = []                # the new load order
-        self.datadir = None                # where plugins live
-        self.plugin_file = None            # Path to the file containing the plugin list
         self.graph = pluggraph.pluggraph()
         self.is_sorted = False
-        self.game_type = None              # 'Morrowind', 'Oblivion', or None for unknown
         self.caseless = fileFinder.caseless_filenames()
 
+        # self.datadir = None                # where plugins live
+        # self.plugin_file = None            # Path to the file containing the plugin list
+        # self.game_type = None              # 'Morrowind', 'Oblivion', or None for unknown
         self.game_type, self.plugin_file, self.datadir = fileFinder.find_game_dirs()
 
     def get_active_plugins(self):

--- a/mlox/modules/loadOrder.py
+++ b/mlox/modules/loadOrder.py
@@ -233,8 +233,8 @@ class loadorder:
         # but we only care about active plugins.
         sorted_datafiles = [f for f in sorted_plugins if f in self.order]
         (esm_files, esp_files) = configHandler.partition_esps_and_esms(sorted_datafiles)
-        new_order_cname = [p for p in esm_files + esp_files]
-        self.new_order = [self.caseless.truename(p) for p in new_order_cname]
+        new_order_cname = esm_files + esp_files
+        self.new_order = list(map(self.caseless.truename, new_order_cname))
 
         order_logger.debug("New load order:")
         for p in self.get_new_order():
@@ -252,7 +252,7 @@ class loadorder:
         if self.datadir != None:
             # these are things we do not want to do if just testing a load order from a file
             # save the load orders to file for future reference
-            self.save_order(old_loadorder_output, [self.caseless.truename(p) for p in self.order], "current")
+            self.save_order(old_loadorder_output, list(map(self.caseless.truename, self.order)), "current")
             self.save_order(new_loadorder_output, self.new_order, "mlox sorted")
         return parser.get_messages()
 

--- a/mlox/modules/pluggraph.py
+++ b/mlox/modules/pluggraph.py
@@ -61,13 +61,27 @@ class pluggraph:
             return False
         self.nodes.setdefault(plug1, [])
         if plug2 in self.nodes[plug1]: # edge already exists
-            pluggraph_logger.debug("%s: Dup Edge: \"%s\" -> \"%s\"" % (where, plug1, plug2))
+            pluggraph_logger.debug("%s: Not adding duplicate Edge: \"%s\" -> \"%s\"", where, plug1, plug2)
             return True
         # add plug2 to the graph as a child of plug1
         self.nodes[plug1].append(plug2)
         self.incoming_count[plug2] = self.incoming_count.setdefault(plug2, 0) + 1
         pluggraph_logger.debug("adding edge: %s -> %s" % (plug1, plug2))
         return(True)
+
+    def get_dot_graph(self):
+        """
+        Produce a graphviz dot graph.
+
+        This is mostly a novelty to visualize what's going on
+        """
+        buffer = "digraph plugins {\n"
+        for (node, plugins) in self.nodes.items():
+            for a_plugin in plugins:
+                buffer += "\""+ node + "\" -> \"" + a_plugin + "\"\n"
+        buffer += "}\n"
+        return buffer
+
 
     def explain(self, what, active):
         seen = {}

--- a/mlox/modules/pluggraph.py
+++ b/mlox/modules/pluggraph.py
@@ -82,7 +82,6 @@ class pluggraph:
         buffer += "}\n"
         return buffer
 
-
     def explain(self, what, active):
         seen = {}
         output = ""

--- a/mlox/modules/pluggraph.py
+++ b/mlox/modules/pluggraph.py
@@ -82,7 +82,10 @@ class pluggraph:
         buffer += "}\n"
         return buffer
 
-    def explain(self, what, active):
+    def explain(self, what, active_plugins):
+        """
+        Tell the user all the plugins mlox thinks should follow <what>
+        """
         seen = {}
         output = ""
         output += "This is a picture of all the plugins mlox thinks should follow {0}\n".format(what)
@@ -96,7 +99,7 @@ class pluggraph:
             seen[n] = True
             if n in self.nodes:
                 for child in self.nodes[n]:
-                    prefix = indent.replace(" ", "+") if child in active else indent.replace(" ", "=")
+                    prefix = indent.replace(" ", "+") if child in active_plugins else indent.replace(" ", "=")
                     output += "%s%s\n" % (prefix, child)
                     explain_rec(" " + indent, child)
             return output

--- a/mlox/modules/qtGui.py
+++ b/mlox/modules/qtGui.py
@@ -180,8 +180,6 @@ class MloxGui(QObject):
             self.lo.read_from_file(fromfile)
         else:
             self.lo.get_active_plugins()
-            if self.lo.order == []:
-                self.lo.get_data_files()
         progress = CustomProgressDialog()
         self.Msg = self.lo.update(progress)
         # self.Msg = self.lo.update()

--- a/mlox/modules/qtGui.py
+++ b/mlox/modules/qtGui.py
@@ -9,9 +9,9 @@ from PyQt5.QtGui import QClipboard
 from PyQt5.QtCore import QUrl, QObject, pyqtSignal, pyqtSlot
 from PyQt5.QtWidgets import QApplication, QDialog, QProgressDialog, QPlainTextEdit
 from PyQt5.QtQml import QQmlApplicationEngine
-from modules.resources import qml_file
-from modules.loadOrder import loadorder
-import modules.version as version
+from .resources import qml_file
+from .loadOrder import loadorder
+from . import version
 
 gui_logger = logging.getLogger('mlox.gui')
 

--- a/mlox/modules/ruleParser.py
+++ b/mlox/modules/ruleParser.py
@@ -1,11 +1,11 @@
 
-import os         #To calculate the amount remaining to parse (os.path.getsize)
+import os
 import re
 import io
 import logging
 from pprint import PrettyPrinter
-import modules.pluggraph as pluggraph
-import modules.fileFinder as fileFinder
+from . import pluggraph
+from . import fileFinder
 
 # comments start with ';'
 re_comment = re.compile(r'(?:^|\s);.*$')

--- a/mlox/modules/ruleParser.py
+++ b/mlox/modules/ruleParser.py
@@ -121,8 +121,8 @@ class rule_parser:
     """A simple recursive descent rule parser, for evaluating rule statements containing nested boolean expressions."""
     version = "Unkown"
 
-    def __init__(self, active, graph, datadir, name_converter):
-        self.active = active
+    def __init__(self, plugin_list, graph, datadir, name_converter):
+        self.plugin_list = plugin_list
         self.graph = graph
         self.datadir = datadir
         self.line_num = 0
@@ -195,11 +195,11 @@ class rule_parser:
             pat = re_plugin_metaver.sub(plugin_version, pat)
             subbed = True
         if not subbed:        # no expansions made
-            return([plugin] if plugin.lower() in self.active else [])
+            return([plugin] if plugin.lower() in self.plugin_list else [])
         parse_logger.debug("expand_filename new RE pat: %s" % pat)
         matches = []
         re_namepat = re.compile(pat, re.IGNORECASE)
-        for p in self.active:
+        for p in self.plugin_list:
             if re_namepat.match(p):
                 matches.append(p)
                 parse_logger.debug("expand_filename: %s expands to: %s" % (plugin, p))

--- a/mlox/modules/ruleParser.py
+++ b/mlox/modules/ruleParser.py
@@ -93,13 +93,13 @@ def plugin_description(plugin):
     try:
         inp = open(plugin, 'rb')
     except IOError:
-        parse_logger.warn("Unable to open plugin file:  {0}".format(plugin))
+        parse_logger.warning("Unable to open plugin file:  {0}".format(plugin))
         return("")
     block = inp.read(4096)
     inp.close()
     if block[0:4] == "TES3":    # Morrowind
         if len(block) < tes3_min_plugin_size:
-            parse_logger.warn("Cannot read plugin description(%s): file too short, returning NULL string" % plugin)
+            parse_logger.warning("Cannot read plugin description(%s): file too short, returning NULL string", plugin)
             return("")
         desc = block[64:block.find("\x00", 64)]
         return(desc)

--- a/mlox/modules/ruleParser.py
+++ b/mlox/modules/ruleParser.py
@@ -57,8 +57,13 @@ tes3_min_plugin_size = 362
 
 parse_logger = logging.getLogger('mlox.parser')
 
-#Get the version information from a plugin
+
 def get_version(plugin,data_dir = None):
+    """
+    Get the version information from a plugin
+
+    :return: A tuple containing the version extracted from the file name, and the version from the plugin's description.
+    """
     match = re_filename_version.search(plugin)
     file_ver = match.group(1) if match else None
     desc_ver = None
@@ -88,6 +93,7 @@ def format_version(ver):
     while len(v) < 3:
         v.append(0)
     return("%05d.%05d.%05d.%s" % (v[0], v[1], v[2], alpha))
+
 
 def plugin_description(plugin):
     """Read the description field of a TES3/TES4 plugin file header"""
@@ -120,9 +126,10 @@ def plugin_description(plugin):
     else:
         return ""
 
+
 class rule_parser:
     """A simple recursive descent rule parser, for evaluating rule statements containing nested boolean expressions."""
-    version = "Unkown"
+    version = "Unknown"
 
     def __init__(self, plugin_list, datadir, name_converter):
         self.plugin_list = plugin_list

--- a/mlox/modules/ruleParser.py
+++ b/mlox/modules/ruleParser.py
@@ -126,8 +126,12 @@ class rule_parser:
 
     def __init__(self, plugin_list, datadir, name_converter):
         self.plugin_list = plugin_list
+        if datadir:
+            self.datadir = fileFinder.caseless_dirlist(datadir)
+        else:
+            self.datadir = None
+        self.name_converter = name_converter
         self.graph = pluggraph.pluggraph()
-        self.datadir = datadir
         self.line_num = 0
         self.rule_file = None
         self.bytesread = 0
@@ -137,7 +141,6 @@ class rule_parser:
         self.curr_rule = ""     # name of the current rule we are parsing
         self.parse_dbg_indent = ""
         self.out_stream = io.StringIO()
-        self.name_converter = name_converter
 
     def _readline(self):
         """

--- a/mlox/modules/ruleParser.py
+++ b/mlox/modules/ruleParser.py
@@ -95,27 +95,30 @@ def plugin_description(plugin):
         inp = open(plugin, 'rb')
     except IOError:
         parse_logger.warning("Unable to open plugin file:  {0}".format(plugin))
-        return("")
+        return ""
     block = inp.read(4096)
     inp.close()
-    if block[0:4] == "TES3":    # Morrowind
+    if block[0:4] == b"TES3":    # Morrowind
         if len(block) < tes3_min_plugin_size:
             parse_logger.warning("Cannot read plugin description(%s): file too short, returning NULL string", plugin)
-            return("")
-        desc = block[64:block.find("\x00", 64)]
-        return(desc)
-    elif block[0:4] == "TES4":  # Oblivion
+            return ""
+        desc = block[64:block.find(b"\x00", 64)]
+        return str(desc)
+    elif block[0:4] == b"TES4":  # Oblivion
         # This is very cheesy.
-        pos = block.find("SNAM", 0)
-        if pos == -1: return("")
-        desc_start = block.find("\x00", pos) + 1
-        if desc_start == -1: return("")
-        desc_end = block.find("\x00", desc_start)
-        if desc_end == -1: return("")
+        pos = block.find(b"SNAM", 0)
+        if pos == -1:
+            return ""
+        desc_start = block.find(b"\x00", pos) + 1
+        if desc_start == -1:
+            return ""
+        desc_end = block.find(b"\x00", desc_start)
+        if desc_end == -1:
+            return ""
         desc = block[desc_start:desc_end]
-        return(desc)
+        return str(desc)
     else:
-        return("")
+        return ""
 
 class rule_parser:
     """A simple recursive descent rule parser, for evaluating rule statements containing nested boolean expressions."""

--- a/mlox/modules/ruleParser.py
+++ b/mlox/modules/ruleParser.py
@@ -121,9 +121,9 @@ class rule_parser:
     """A simple recursive descent rule parser, for evaluating rule statements containing nested boolean expressions."""
     version = "Unkown"
 
-    def __init__(self, plugin_list, graph, datadir, name_converter):
+    def __init__(self, plugin_list, datadir, name_converter):
         self.plugin_list = plugin_list
-        self.graph = graph
+        self.graph = pluggraph.pluggraph()
         self.datadir = datadir
         self.line_num = 0
         self.rule_file = None
@@ -661,3 +661,11 @@ class rule_parser:
         This includes everything from mild notes, to major warnings.
         """
         return self.out_stream.getvalue()
+
+    def get_graph(self):
+        """
+        Get the generated load order graph.
+
+        NOTE:  This graph DOES NOT take the original load order into consideration.
+        """
+        return self.graph

--- a/mlox/modules/ruleParser.py
+++ b/mlox/modules/ruleParser.py
@@ -136,7 +136,12 @@ class rule_parser:
         self.name_converter = name_converter
 
     def readline(self):
-        """reads a line into the current parsing buffer"""
+        """
+        Obtain the next line from the rules file.
+
+        This skips blank lines, and lines that are only comments.
+        It also strips comments.
+        """
         if self.input_handle == None:
             return(False)
         try:

--- a/mlox/modules/translations.py
+++ b/mlox/modules/translations.py
@@ -1,7 +1,7 @@
 
 import locale
 import codecs
-from modules.resources import translation_file
+from .resources import translation_file
 
 # Utility functions
 Lang = locale.getdefaultlocale()[0]

--- a/test/module_test.py
+++ b/test/module_test.py
@@ -34,9 +34,9 @@ class fileFinder_test(unittest.TestCase):
 
         #Multi-line check here
         (a,b,c) = fileFinder.find_game_dirs()
-        self.assertTrue(a == None)
-        self.assertTrue(b == None)
-        self.assertEqual(c.dirpath(),os.path.abspath('..'))
+        self.assertTrue(a is None)
+        self.assertTrue(b is None)
+        self.assertEqual(c, os.path.abspath('..'))
 
         #TODO:  Actually test these two (seperately)
         #print(fileFinder.filter_dup_files(dir_list.filelist()))
@@ -207,21 +207,19 @@ class parser_pluggraph_test(unittest.TestCase):
                    'lgnpc_aldruhn_v1_13-jms_patch.esp', 'mashed lists.esp']
 
     def test_parser_base_version_good(self):
-        graph = self.pluggraph.pluggraph()
-        myParser = self.ruleParser.rule_parser([],graph,"",sys.stdout,self.file_names)
+        myParser = self.ruleParser.rule_parser([],"",self.file_names)
         myParser.read_rules("../data/mlox_base.txt")
-        self.assertNotEqual(myParser.version,"Unkown")
+        self.assertNotEqual(myParser.version,"Unknown")
 
     def test_parser_base_version_bad(self):
-        graph = self.pluggraph.pluggraph()
-        myParser = self.ruleParser.rule_parser([],graph,"",sys.stdout,self.file_names)
+        myParser = self.ruleParser.rule_parser([],"",self.file_names)
         myParser.read_rules("./test1.data/mlox_base.txt")
-        self.assertEqual(myParser.version,"Unkown")
+        self.assertEqual(myParser.version,"Unknown")
 
     def test_parser_graph(self):
-        graph = self.pluggraph.pluggraph()
-        myParser = self.ruleParser.rule_parser([],graph,"./test1.data/",sys.stdout,self.file_names)
+        myParser = self.ruleParser.rule_parser([],"./test1.data/",self.file_names)
         myParser.read_rules("./test1.data/mlox_base.txt")
+        graph=myParser.get_graph()
         self.assertEqual(graph.topo_sort(),self.test1_graph)
 
     #TODO:  d_ver doesn't seem correct
@@ -239,7 +237,7 @@ class loadOrder_test(unittest.TestCase):
 
     def test_File_and_Dir(self):
         l1 = self.loadorder()
-        l1.datadir = self.fileFinder.caseless_dirlist("./test1.data/")
+        l1.datadir = "./test1.data/"
         l1.plugin_file = "./userfiles/abot.txt"
         l1.game_type = None
         l1.get_active_plugins()
@@ -248,7 +246,7 @@ class loadOrder_test(unittest.TestCase):
 
     def test_Dir(self):
         l2 = self.loadorder()
-        l2.datadir = self.fileFinder.caseless_dirlist("./test1.data/")
+        l2.datadir = "./test1.data/"
         l2.get_data_files()
         l2.update()
 

--- a/test/module_test.py
+++ b/test/module_test.py
@@ -44,7 +44,21 @@ class fileFinder_test(unittest.TestCase):
 #Config Handler
 class configHandler_test(unittest.TestCase):
     import modules.configHandler as configHandler
-    zinx_txt=['Better Heads Bloodmoon addon.esm', 'Better Heads Tribunal addon.esm', 'Better Heads.esm', 'Bloodmoon.esm', 'MCA.esm', 'Morrowind.esm', 'Tribunal.esm', 'ACE_Subtitles.esp', 'Balmora Expansion - LITE 1.0.esp', 'Balmora Expansion v1.4.esp', 'BAR_DarkshroudKeep_v1.2.esp', 'Beasts of Burden Necromancer.esp', 'Better Bodies.esp', 'Better Clothes_v1.0_nac.esp', 'BE_dh_furn_stores .esp', 'BE_Personal_Fix.esp', 'Blasphemous Revenants.esp', 'BR Dead Heros.esp', 'Dark_Stone_Fortress.esp', 'Flee AI Tweaks.esp', 'IceNioLivRobeReplacerALL.esp', 'Illuminated Order v1.0 - Bloodmoon Compatibility Extras.esp', 'Illuminated Order v1.0.esp', 'indybank.esp', 'Level List Merger.esp', 'MCA - Guards Patch.esp', 'MCA - Personal Fix.esp', 'MCA - Vampire Realism Patch.esp', 'MTT Vol III.esp', 'MWE_Base.esp', 'MWE_Combat.esp', 'MWE_Writing.esp', 'Necro Armor v1_0.esp', 'Propylon Fix.esp', 'Quest Fix.esp', 'Scripted_Spells.esp', 'Slave Trade.esp', "Slof's BB neck fix.esp", "Slof's Better Beasts b.esp", 'Vampire Realism II - BM Add-On.esp', 'Vampire Realism II - TB Add-On.esp', 'Vampire Realism II - VE Patch.esp', 'Vampire Realism II.esp', 'Vampire_Embrace.esp', 'Vampire_Werewolf.esp', "Wakim's Game Improvement 9.esp", 'werewolfrealism-moononly.esp', 'Werewolf_Evolution.esp']
+    zinx_txt = ['Better Heads Bloodmoon addon.esm', 'Better Heads Tribunal addon.esm', 'Better Heads.esm',
+                'Bloodmoon.esm', 'MCA.esm', 'Morrowind.esm', 'Tribunal.esm', 'ACE_Subtitles.esp',
+                'Balmora Expansion - LITE 1.0.esp', 'Balmora Expansion v1.4.esp', 'BAR_DarkshroudKeep_v1.2.esp',
+                'Beasts of Burden Necromancer.esp', 'Better Bodies.esp', 'Better Clothes_v1.0_nac.esp',
+                'BE_dh_furn_stores .esp', 'BE_Personal_Fix.esp', 'Blasphemous Revenants.esp', 'BR Dead Heros.esp',
+                'Dark_Stone_Fortress.esp', 'Flee AI Tweaks.esp', 'IceNioLivRobeReplacerALL.esp',
+                'Illuminated Order v1.0 - Bloodmoon Compatibility Extras.esp', 'Illuminated Order v1.0.esp',
+                'indybank.esp', 'Level List Merger.esp', 'MCA - Guards Patch.esp', 'MCA - Personal Fix.esp',
+                'MCA - Vampire Realism Patch.esp', 'MTT Vol III.esp', 'MWE_Base.esp', 'MWE_Combat.esp',
+                'MWE_Writing.esp', 'Necro Armor v1_0.esp', 'Propylon Fix.esp', 'Quest Fix.esp', 'Scripted_Spells.esp',
+                'Slave Trade.esp', "Slof's BB neck fix.esp", "Slof's Better Beasts b.esp",
+                'Vampire Realism II - BM Add-On.esp', 'Vampire Realism II - TB Add-On.esp',
+                'Vampire Realism II - VE Patch.esp', 'Vampire Realism II.esp', 'Vampire_Embrace.esp',
+                'Vampire_Werewolf.esp', "Wakim's Game Improvement 9.esp", 'werewolfrealism-moononly.esp',
+                'Werewolf_Evolution.esp']
 
     # Get  list of plugins (in order from the correct directory)
     test1_plugins_raw = subprocess.check_output('cd test1.data; ( ls -rt *.esm ; ls -rt *.esp ) | col', shell=True)
@@ -53,7 +67,30 @@ class configHandler_test(unittest.TestCase):
     modified_plugins = list(test1_plugins)
     modified_plugins[-2] = test1_plugins[-1]
     modified_plugins[-1] = test1_plugins[-2]
-    morrowind_ini = ['Morrowind.esm', 'Tribunal.esm', 'BLOODMOON.esm', 'GIANTS.esm', 'TR_Data.esm', 'TR_Map1.esm', 'TR_Map2.esm', 'Better Heads.esm', 'Better Heads Tribunal addon.esm', 'Better Heads Bloodmoon addon.esm', 'BT_Whitewolf_2_0.esm', 'The Wilderness Mod 2.0.esm', 'The Wilderness Mod 2.0 T & B.esm', 'Morrowind Comes Alive.esm', 'Morrowind Patch v1.6.5-BETA.esm', 'fem_body.esp', 'Zed.esp', 'RealSignposts.esp', 'Passive_Healthy_Wildlife.esp', 'entertainers.esp', 'AreaEffectArrows.esp', 'bcsounds.esp', 'LeFemmArmor.esp', 'adamantiumarmor.esp', 'EBQ_Artifact.esp', 'Siege at Firemoth.esp', 'A good place to stay, Teleport Addon.esp', 'A good place to stay, Ver 1,8.esp', 'No-Glo_0709.esp', 'Clean Water Nymph race.esp', 'female_cuirasses_2.0.esp', 'Weapon Wielding Mannequins.esp', 'Nerevarine Greeting tweaks.esp', 'Aduls_Artifact_Replace_(Trueflame).esp', 'GIANTS Ultimate Control file.esp', 'Blood and Gore.esp', 'Better Bodies.esp', 'Meteor.esp', 'HelioS - Giants Fix.esp', 'Silt_Striders_Are_In_Vvardenfell.esp', "Taddeus'BalancedArmors.esp", 'CET_Meteoric_Steel_Mail.esp', 'Vivec Signposts.esp', 'Amazon War Boots 1.0.esp', 'Annastia V3.3.esp', 'indybankWC.esp', 'MTT IV Master.esp', "Taddeus'BalancedObjects.esp", 'Amazon Platemail Greaves 2.0.esp', 'GIANTS_Ultimate_Official_Fixes.esp', 'Sexy Daedric Armor v1.1.esp', 'Morrowind Comes Alive Guards Patch.esp', 'MCAnames4.1lorecorrect.esp', 'Clean BB_Tshirt_and_Skirt.esp', 'Sexy Ordinator Armor 2.esp', 'Sexy Glass Armor v1.1.esp', 'Sexy Ice Armor v1.1.esp', 'Amazon Tops.esp', "Bob's Armory.esp", 'Clean Better Daedric.esp', 'Better Solsthiem Creatures.esp', 'Sexy Ebony Armor.esp', "Unofficial_Expansion_for_Louis'_BeautyShop.esp", 'BT_Whitewolf_2_0.esp', 'EarthlyDelights.esp', 'Better Clothes Beta_1.4.esp', 'ARJAN_A_Lords_Men_v2.0.esp', 'Louis_BeautyShop_v1.5.esp', 'StripForMe.esp', 'KeyNamer.esp', 'ModMan_windowlights_full_2.esp', 'Lockpick__Probe_Weight_Fix.esp', 'Wolfen Castle.esp', 'Tribun_Laura_3_0.esp', 'master_index.esp', 'Merged_Objects.esp', 'Merged_Dialogs.esp', 'Merged_Leveled_Lists.esp']
+    morrowind_ini = ['Morrowind.esm', 'Tribunal.esm', 'BLOODMOON.esm', 'GIANTS.esm', 'TR_Data.esm', 'TR_Map1.esm',
+                     'TR_Map2.esm', 'Better Heads.esm', 'Better Heads Tribunal addon.esm',
+                     'Better Heads Bloodmoon addon.esm', 'BT_Whitewolf_2_0.esm', 'The Wilderness Mod 2.0.esm',
+                     'The Wilderness Mod 2.0 T & B.esm', 'Morrowind Comes Alive.esm', 'Morrowind Patch v1.6.5-BETA.esm',
+                     'fem_body.esp', 'Zed.esp', 'RealSignposts.esp', 'Passive_Healthy_Wildlife.esp', 'entertainers.esp',
+                     'AreaEffectArrows.esp', 'bcsounds.esp', 'LeFemmArmor.esp', 'adamantiumarmor.esp',
+                     'EBQ_Artifact.esp', 'Siege at Firemoth.esp', 'A good place to stay, Teleport Addon.esp',
+                     'A good place to stay, Ver 1,8.esp', 'No-Glo_0709.esp', 'Clean Water Nymph race.esp',
+                     'female_cuirasses_2.0.esp', 'Weapon Wielding Mannequins.esp', 'Nerevarine Greeting tweaks.esp',
+                     'Aduls_Artifact_Replace_(Trueflame).esp', 'GIANTS Ultimate Control file.esp', 'Blood and Gore.esp',
+                     'Better Bodies.esp', 'Meteor.esp', 'HelioS - Giants Fix.esp',
+                     'Silt_Striders_Are_In_Vvardenfell.esp', "Taddeus'BalancedArmors.esp",
+                     'CET_Meteoric_Steel_Mail.esp', 'Vivec Signposts.esp', 'Amazon War Boots 1.0.esp',
+                     'Annastia V3.3.esp', 'indybankWC.esp', 'MTT IV Master.esp', "Taddeus'BalancedObjects.esp",
+                     'Amazon Platemail Greaves 2.0.esp', 'GIANTS_Ultimate_Official_Fixes.esp',
+                     'Sexy Daedric Armor v1.1.esp', 'Morrowind Comes Alive Guards Patch.esp',
+                     'MCAnames4.1lorecorrect.esp', 'Clean BB_Tshirt_and_Skirt.esp', 'Sexy Ordinator Armor 2.esp',
+                     'Sexy Glass Armor v1.1.esp', 'Sexy Ice Armor v1.1.esp', 'Amazon Tops.esp', "Bob's Armory.esp",
+                     'Clean Better Daedric.esp', 'Better Solsthiem Creatures.esp', 'Sexy Ebony Armor.esp',
+                     "Unofficial_Expansion_for_Louis'_BeautyShop.esp", 'BT_Whitewolf_2_0.esp', 'EarthlyDelights.esp',
+                     'Better Clothes Beta_1.4.esp', 'ARJAN_A_Lords_Men_v2.0.esp', 'Louis_BeautyShop_v1.5.esp',
+                     'StripForMe.esp', 'KeyNamer.esp', 'ModMan_windowlights_full_2.esp',
+                     'Lockpick__Probe_Weight_Fix.esp', 'Wolfen Castle.esp', 'Tribun_Laura_3_0.esp', 'master_index.esp',
+                     'Merged_Objects.esp', 'Merged_Dialogs.esp', 'Merged_Leveled_Lists.esp']
 
     #Can't use the logging check with python 2.7...
     def test_No_File(self):
@@ -113,9 +150,61 @@ class parser_pluggraph_test(unittest.TestCase):
     import modules.pluggraph as pluggraph
     import modules.fileFinder as fileFinder
     file_names = fileFinder.caseless_filenames()
-    test1_graph=['morrowind.esm', 'tribunal.esm', 'bloodmoon.esm', 'morrowind patch v1.6.4 (wip).esm', 'rf - furniture shop.esm', 'metalqueenboutique.esm', 'book rotate.esm', 'gdr_masterfile.esm', 'bt_whitewolf_2_0.esm', 'tr_data.esm', 'tr_map1.esm', 'the undead.esm', 'text patch for morrowind with tribunal & bloodmoon.esp', 'lgnpc_sn.esp', 'realsignposts.esp', 'dagonfel_well.esp', 'myth and murder ver 2.0.esp', "wakim's game improvement 9.esp", 'chessv4.esp', 'lgnpc_nolore_v0_83.esp', 'officialmods_v5.esp', "zyndaar's bows.esp", 'dwemerclock.esp', 'uumpp bloated morrowind patch v1.6.4.esp', 'tlm - light sources (natural water).esp', 'tlm - ambient light + fog update.esp', 'tlm - npc light sources.esp', 'dh_furn.esp', 'dh_furn_stores.esp', 'dh_thriftshop.esp', 'tlm - light sources (lanterns).esp', 'tlm - light sources (clearer lighting).esp', 'p.r.e. v4.0.esp', 'nudity greeting expansion v1.esp', 'book rotate - morrowind v1.1.esp', 'rf - bethesda furniture.esp', 'better bodies.esp', 'silt_striders_are_in_vvardenfell.esp', 'werewolf_evolution.esp', 'rkwerewolf.esp',
-    'vampire_werewolf.esp', 'windows glow.esp', 'unboarable rieklings.esp', 'bm_s_inn.esp', 'smooth moves v1.esp', "slof's vampire faces.esp", 'vampire realism ii.esp', 'vampire realism ii - tb add-on.esp', 'vampire realism ii - bm add-on.esp', 'vampire realism ii - ve patch.esp', 'vampire realism ii - bl patch.esp', 'abotwhereareallbirdsgoing.esp', "ng_new_carnithus'_armamentarium.esp", 'scripted_spells.esp', 'nixie.esp', 'book rotate - tribunal v5.3.esp', 'book rotate - bloodmoon v5.3.esp', 'clean sexy_black_collar_dress_v.1a.esp', 'keynamer.esp', 'tribun_laura_3_0.esp', 'galsiahs character development.esp', 'gcd startscript for trib or bloodmoon.esp', 'gcd better balanced birthsigns.esp', 'gcd restore potions fix.esp', 'gcd_ss_patch.esp', 'brittlewind fix.esp', 'gcd_we_patch.esp', 'drug realism.esp', "juniper's twin lamps (1.1 tribunal).esp", 'gcd_107x_to_108_patch.esp', 'vampire_embrace.esp', 'sslave_companions.esp', 'bt_wwlokpatch1.esp', 'vampiric hunger base.esp', 'vampiric hunger extended.esp', 'vampiric hunger - su.esp', 'gcd_vh_patch2.esp', 'arjan_a_lords_men_v2.0.esp', 'book jackets - morrowind - bookrotate.esp', 'dm_db armor replacer.esp', "slof's goth shop ii.esp", 'bb_clothiers_of_vvardenfell_v1.1.esp', 'expanded sounds.esp', 'iceniolivrobereplacerall.esp', 'barons_partners30.esp', "slof's pillow book.esp", 'theubercrystalegghunt.esp',
-    'better clothes_v1.1_nac.esp', 'clean tales of seyda neen.esp', 'lgnpc_indarys_manor_v1_45.esp', 'new argonian bodies - mature.esp', 'lgnpc_gnaarmok_v1_10.esp', 'lgnpc_aldvelothi_v1_20.esp', 'lgnpc_maargan_v1_10.esp', 'new khajiit bodies - mature.esp', 'lgnpc_secret_masters_v1_21.esp', 'gothic attire complete v1-1.esp', "building up uvirith's grave 1.1.esp", 'secrets of vvardenfell.esp', 'the_vvardenfell_libraries.esp', 'lgnpc_hlaoad_v1_32.esp', 'nede v1.2.esp', 'nede wgi patch.esp', 'rts_faeriesseydaneen.esp', 'rts_healingfaeries.esp', 'sris_alchemy_bm.esp', 'sri alchemy bm list patch.esp', 'creatures.esp', 'creaturesx-jms_patch.esp', 'dn-gdrv1.esp', 'syc_herbalismforpurists.esp', 'syc_herbalismforpurists_bm.esp', 'syc_herbalismforpurists_tb.esp', 'syc_herbalism es patch.esp', 'multimark.esp', 'multimark_firemothplugin.esp', 'multimark_tribunalplugin.esp', 'multimark_bloodmoonplugin.esp', 'multimark-jms_patch.esp', 'all silt strider ports.esp', 'all boat ports.esp', 'vampire_embrace-jms_patch.esp', 'dh_thriftshop-jms_patch.esp', 'k_potion_upgrade_1.2.esp', 'vampire_embrace-jms_combat_bite_patch.esp', 'syc_herbalismforpurists-jms_patch.esp', 'jms-shishi_door_fix.esp', 'moons_soulgems.esp', 'suran_underworld_2.5.esp', 'lgnpc_aldruhn_v1_13.esp', 'suran_underworld_2.5-jms_patch.esp', 'bt_whitewolf_2_0-jms_patch.esp', 'lgnpc_pelagiad_v1_13.esp', 'lgnpc_telmora_v1_11.esp', 'chargen_revamped_v14.esp', 'chargen revamped delay2.esp', 'lgnpc_khuul_v2_01.esp', 'lgnpc_vivecfq_v2_03.esp', 'tribunal-jms_patch.esp', 'lgnpc_teluvirith_v1_10.esp', 'lgnpc_vivecredoran_v1_40.esp', 'lgnpc_paxredoran_v1_11.esp', 'dx_creatureadditionsv1.0.esp', 'betterclothes_patch.esp', 'buug alchemy- bloodmoon.esp', 'buug alchemy- srikandi.esp', 'buug alchemy- tribunal.esp', 'pk_tatyshirt.esp', 'clean tales of the bitter coast.esp', 'clean tales of tel branora.esp', 'tr_map1-jms_patch.esp', 'chalk30-base.esp', 'dh_furn-jms_patch.esp', 'mtt_iv_master.esp', 'jms-springheel_boots.esp', 'morrowind-jms_patch.esp', 'dn-gdrv1-jms_patch.esp', 'lgnpc_paxredoran_v1_11-jms_patch.esp', 'vampire_embrace-jms_follow_patch.esp', 'jms-ring_of_mojo.esp', 'vampire_embrace-jms_combat_bite_patch-2.esp', 'lgnpc_aldruhn_v1_13-jms_patch.esp', 'mashed lists.esp']
+    test1_graph = ['morrowind.esm', 'tribunal.esm', 'bloodmoon.esm', 'morrowind patch v1.6.4 (wip).esm',
+                   'rf - furniture shop.esm', 'metalqueenboutique.esm', 'book rotate.esm', 'gdr_masterfile.esm',
+                   'bt_whitewolf_2_0.esm', 'tr_data.esm', 'tr_map1.esm', 'the undead.esm',
+                   'text patch for morrowind with tribunal & bloodmoon.esp', 'lgnpc_sn.esp', 'realsignposts.esp',
+                   'dagonfel_well.esp', 'myth and murder ver 2.0.esp', "wakim's game improvement 9.esp", 'chessv4.esp',
+                   'lgnpc_nolore_v0_83.esp', 'officialmods_v5.esp', "zyndaar's bows.esp", 'dwemerclock.esp',
+                   'uumpp bloated morrowind patch v1.6.4.esp', 'tlm - light sources (natural water).esp',
+                   'tlm - ambient light + fog update.esp', 'tlm - npc light sources.esp', 'dh_furn.esp',
+                   'dh_furn_stores.esp', 'dh_thriftshop.esp', 'tlm - light sources (lanterns).esp',
+                   'tlm - light sources (clearer lighting).esp', 'p.r.e. v4.0.esp', 'nudity greeting expansion v1.esp',
+                   'book rotate - morrowind v1.1.esp', 'rf - bethesda furniture.esp', 'better bodies.esp',
+                   'silt_striders_are_in_vvardenfell.esp', 'werewolf_evolution.esp', 'rkwerewolf.esp',
+                   'vampire_werewolf.esp', 'windows glow.esp', 'unboarable rieklings.esp', 'bm_s_inn.esp',
+                   'smooth moves v1.esp', "slof's vampire faces.esp", 'vampire realism ii.esp',
+                   'vampire realism ii - tb add-on.esp', 'vampire realism ii - bm add-on.esp',
+                   'vampire realism ii - ve patch.esp', 'vampire realism ii - bl patch.esp',
+                   'abotwhereareallbirdsgoing.esp', "ng_new_carnithus'_armamentarium.esp", 'scripted_spells.esp',
+                   'nixie.esp', 'book rotate - tribunal v5.3.esp', 'book rotate - bloodmoon v5.3.esp',
+                   'clean sexy_black_collar_dress_v.1a.esp', 'keynamer.esp', 'tribun_laura_3_0.esp',
+                   'galsiahs character development.esp', 'gcd startscript for trib or bloodmoon.esp',
+                   'gcd better balanced birthsigns.esp', 'gcd restore potions fix.esp', 'gcd_ss_patch.esp',
+                   'brittlewind fix.esp', 'gcd_we_patch.esp', 'drug realism.esp',
+                   "juniper's twin lamps (1.1 tribunal).esp", 'gcd_107x_to_108_patch.esp', 'vampire_embrace.esp',
+                   'sslave_companions.esp', 'bt_wwlokpatch1.esp', 'vampiric hunger base.esp',
+                   'vampiric hunger extended.esp', 'vampiric hunger - su.esp', 'gcd_vh_patch2.esp',
+                   'arjan_a_lords_men_v2.0.esp', 'book jackets - morrowind - bookrotate.esp',
+                   'dm_db armor replacer.esp', "slof's goth shop ii.esp", 'bb_clothiers_of_vvardenfell_v1.1.esp',
+                   'expanded sounds.esp', 'iceniolivrobereplacerall.esp', 'barons_partners30.esp',
+                   "slof's pillow book.esp", 'theubercrystalegghunt.esp',
+                   'better clothes_v1.1_nac.esp', 'clean tales of seyda neen.esp', 'lgnpc_indarys_manor_v1_45.esp',
+                   'new argonian bodies - mature.esp', 'lgnpc_gnaarmok_v1_10.esp', 'lgnpc_aldvelothi_v1_20.esp',
+                   'lgnpc_maargan_v1_10.esp', 'new khajiit bodies - mature.esp', 'lgnpc_secret_masters_v1_21.esp',
+                   'gothic attire complete v1-1.esp', "building up uvirith's grave 1.1.esp",
+                   'secrets of vvardenfell.esp', 'the_vvardenfell_libraries.esp', 'lgnpc_hlaoad_v1_32.esp',
+                   'nede v1.2.esp', 'nede wgi patch.esp', 'rts_faeriesseydaneen.esp', 'rts_healingfaeries.esp',
+                   'sris_alchemy_bm.esp', 'sri alchemy bm list patch.esp', 'creatures.esp', 'creaturesx-jms_patch.esp',
+                   'dn-gdrv1.esp', 'syc_herbalismforpurists.esp', 'syc_herbalismforpurists_bm.esp',
+                   'syc_herbalismforpurists_tb.esp', 'syc_herbalism es patch.esp', 'multimark.esp',
+                   'multimark_firemothplugin.esp', 'multimark_tribunalplugin.esp', 'multimark_bloodmoonplugin.esp',
+                   'multimark-jms_patch.esp', 'all silt strider ports.esp', 'all boat ports.esp',
+                   'vampire_embrace-jms_patch.esp', 'dh_thriftshop-jms_patch.esp', 'k_potion_upgrade_1.2.esp',
+                   'vampire_embrace-jms_combat_bite_patch.esp', 'syc_herbalismforpurists-jms_patch.esp',
+                   'jms-shishi_door_fix.esp', 'moons_soulgems.esp', 'suran_underworld_2.5.esp',
+                   'lgnpc_aldruhn_v1_13.esp', 'suran_underworld_2.5-jms_patch.esp', 'bt_whitewolf_2_0-jms_patch.esp',
+                   'lgnpc_pelagiad_v1_13.esp', 'lgnpc_telmora_v1_11.esp', 'chargen_revamped_v14.esp',
+                   'chargen revamped delay2.esp', 'lgnpc_khuul_v2_01.esp', 'lgnpc_vivecfq_v2_03.esp',
+                   'tribunal-jms_patch.esp', 'lgnpc_teluvirith_v1_10.esp', 'lgnpc_vivecredoran_v1_40.esp',
+                   'lgnpc_paxredoran_v1_11.esp', 'dx_creatureadditionsv1.0.esp', 'betterclothes_patch.esp',
+                   'buug alchemy- bloodmoon.esp', 'buug alchemy- srikandi.esp', 'buug alchemy- tribunal.esp',
+                   'pk_tatyshirt.esp', 'clean tales of the bitter coast.esp', 'clean tales of tel branora.esp',
+                   'tr_map1-jms_patch.esp', 'chalk30-base.esp', 'dh_furn-jms_patch.esp', 'mtt_iv_master.esp',
+                   'jms-springheel_boots.esp', 'morrowind-jms_patch.esp', 'dn-gdrv1-jms_patch.esp',
+                   'lgnpc_paxredoran_v1_11-jms_patch.esp', 'vampire_embrace-jms_follow_patch.esp',
+                   'jms-ring_of_mojo.esp', 'vampire_embrace-jms_combat_bite_patch-2.esp',
+                   'lgnpc_aldruhn_v1_13-jms_patch.esp', 'mashed lists.esp']
 
     def test_parser_base_version_good(self):
         graph = self.pluggraph.pluggraph()
@@ -177,9 +266,6 @@ class version_test(unittest.TestCase):
     def test_internal_version(self):
         self.assertEqual(self.version.Version,'0.62')
 
-    #def test_version_string(self):
-        #self.assertRegexpMatches(self.version.version_info(),' \d*\.\d* \[mlox-base 20\d\d-\d\d-\d\d \d\d:\d\d:\d\d \(UTC\)] \(en_US/UTF-8\)\\nPython Version: \d\.\d\\nwxPython Version: \d\.\d\.\d\.\d\\n')
-
 #Updater
 class update_test(unittest.TestCase):
     import modules.update as update
@@ -192,19 +278,19 @@ class update_test(unittest.TestCase):
         self.temp_dir = tempfile.mkdtemp()
         self.local_file = os.path.join(self.temp_dir, self.file_name)
 
-    def test_isNewer(self):
+    def test_remote_file_changed(self):
         # Make sure the file doesn't exist
-        self.assertTrue(self.update.isNewer(self.local_file,self.test_url))
+        self.assertTrue(self.update.remote_file_changed(self.local_file,self.test_url))
         # Download the file
         subprocess.check_call(['wget', '-O', self.local_file, self.test_url])
         # Make sure the file does exist
-        self.assertFalse(self.update.isNewer(self.local_file, self.test_url))
+        self.assertFalse(self.update.remote_file_changed(self.local_file, self.test_url))
         # Zero the file (so the updater knows it needs updating)
         subprocess.check_call(['truncate', '-s0', self.local_file])
         # Make sure the updater says we need an update
-        self.assertTrue(self.update.isNewer(self.local_file,self.test_url))
+        self.assertTrue(self.update.remote_file_changed(self.local_file,self.test_url))
 
-    def test_extract(self):
+    def test_extract_file(self):
         import hashlib
         # Make a 7z file to test with, and get the hash
         z_file = os.path.join(self.temp_dir, 'module_test.7z')
@@ -212,7 +298,7 @@ class update_test(unittest.TestCase):
         with open('module_test.py', 'rb') as test_file:
             file_hash = hashlib.sha256(test_file.read()).hexdigest()
 
-        self.update.extract(z_file,self.temp_dir)
+        self.update.extract_file(z_file,self.temp_dir)
         with open(os.path.join(self.temp_dir, 'module_test.py'), 'rb') as test_file:
             self.assertTrue(file_hash == hashlib.sha256(test_file.read()).hexdigest())
 

--- a/test/module_test.py
+++ b/test/module_test.py
@@ -310,4 +310,6 @@ class update_test(unittest.TestCase):
         import shutil
         shutil.rmtree(self.temp_dir)
 
-unittest.main()
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/module_test.py
+++ b/test/module_test.py
@@ -92,13 +92,12 @@ class configHandler_test(unittest.TestCase):
                      'Lockpick__Probe_Weight_Fix.esp', 'Wolfen Castle.esp', 'Tribun_Laura_3_0.esp', 'master_index.esp',
                      'Merged_Objects.esp', 'Merged_Dialogs.esp', 'Merged_Leveled_Lists.esp']
 
-    #Can't use the logging check with python 2.7...
     def test_No_File(self):
         """Test reading a file that does not exist"""
-        #with self.assertLogs('mlox.configHandler',level='Error') as l:
-        handleri = self.configHandler.configHandler("No File")
-        self.assertEqual(handleri.read(),[])
-        #self.assertEqual(l.output, ['ERROR:mlox.configHandler:Unable to open config file: No File'])
+        with self.assertLogs('mlox.configHandler',level='ERROR') as l:
+            handleri = self.configHandler.configHandler("No File")
+            self.assertEqual(handleri.read(),[])
+            self.assertEqual(l.output, ['ERROR:mlox.configHandler:Unable to open configuration file: No File'])
 
     def test_Morrowind_only(self):
         """Test reading a file that only contains morrowind game entries"""
@@ -108,11 +107,10 @@ class configHandler_test(unittest.TestCase):
         """Test reading an actual morrowind.ini"""
         self.assertEqual(self.configHandler.configHandler("./testM/Morrowind.ini","Morrowind").read(),self.morrowind_ini)
 
-    #Can't use the logging check with python 2.7...
     def test_Invalid(self):
-        #with self.assertLogs('mlox.configHandler',level='Error') as l:
-        self.assertEqual(self.configHandler.configHandler("./userfiles/zinx.txt","Invalid").read(),self.zinx_txt)
-        #self.assertEqual(l.output, ['WARNING:mlox.configHandler:"Invalid" is not a recognized file type!'])
+        with self.assertLogs('mlox.configHandler',level='WARNING') as l:
+            self.assertEqual(self.configHandler.configHandler("./userfiles/zinx.txt","Invalid").read(),self.zinx_txt)
+            self.assertEqual(l.output, ['WARNING:mlox.configHandler:"Invalid" is not a recognized file type!'])
 
     def test_Default(self):
         self.assertEqual(self.configHandler.configHandler("./userfiles/zinx.txt").read(),self.zinx_txt)


### PR DESCRIPTION
Most of this is re-naming things, and cleaning up / documenting code

rule_parser, and file_finder did experience API changes:

Previously, rule_parser used pass by reference to output most thing.  The references were passed in at object creation.  This meant `parser.update()` had quite a few side effects.  Most of those are now eliminated.  Unfortunately, I haven't found a good way to handle the whole caseless plugin issue, so that's still modified.

The other change is a reduction in the use of caseless_dirlist.  Previously, this custom Path class was passed around quite a bit.  Now it's only limited to file_finder and rule_parser.  Everything except those two now use simple strings as file paths.  Even then, file_finder and rule_parser now accept and output strings, and only use caseless_dirlist internally.