### PR TITLE
Issue #57 replace -1 timestamp in os.utime() by a safe one for all FS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# mlox - version whith the fix for FAT32 filesystem
+
+This version is a fork to fix the issue with FAT32 filesystem with the original version. You can download this compiled version for Windows [here](https://github.com/cpassuel/mlox/releases/tag/v1.04).
+
 # mlox - the elder scrolls Mod Load Order eXpert
 mlox is a tool for analyzing and sorting your Morrowind plugin load order.
 

--- a/mlox.spec
+++ b/mlox.spec
@@ -8,7 +8,7 @@ a = Analysis(['mlox/__main__.py'],
              binaries=[],
              datas=[
                  ('mlox/static/', 'mlox/static'),  # For static files
-                 (HOMEPATH + '\\PyQt5\\Qt\\bin\\*', 'PyQt5\\Qt\\bin')  # Fixes a bug with Qt
+                 (HOMEPATH + '\\PyQt5\\Qt5\\bin\\*', 'PyQt5\\Qt5\\bin')  # Fixes a bug with Qt
              ],
              hiddenimports=['mlox.static', 'libarchive', 'appdirs', 'PyQt5'],
              hookspath=[],

--- a/mlox/configHandler.py
+++ b/mlox/configHandler.py
@@ -5,6 +5,7 @@ from functools import reduce
 
 config_logger = logging.getLogger('mlox.configHandler')
 
+MIN_SAFE_TIMESTAMP = 315529200  # safe file timestamp for both NTFS and FAT32 fs
 
 def caseless_uniq(un_uniqed_files):
     """
@@ -257,16 +258,16 @@ class dataDirHandler:
             for a_plugin in list_of_plugins:
                 if a_plugin.lower() == "morrowind.esm":
                     mtime = tes3cmd_resetdates_morrowind_mtime
-                    os.utime(self._full_path("Morrowind.bsa"), (-1, mtime))
+                    os.utime(self._full_path("Morrowind.bsa"), (MIN_SAFE_TIMESTAMP, mtime))
                 elif a_plugin.lower() == "tribunal.esm":
                     mtime = tes3cmd_resetdates_tribunal_mtime
-                    os.utime(self._full_path("Tribunal.bsa"), (-1, mtime))
+                    os.utime(self._full_path("Tribunal.bsa"), (MIN_SAFE_TIMESTAMP, mtime))
                 elif a_plugin.lower() == "bloodmoon.esm":
                     mtime = tes3cmd_resetdates_bloodmoon_mtime
-                    os.utime(self._full_path("Bloodmoon.bsa"), (-1, mtime))
+                    os.utime(self._full_path("Bloodmoon.bsa"), (MIN_SAFE_TIMESTAMP, mtime))
                 else:
                     mtime += 60 # standard 1 minute Mash step
-                os.utime(self._full_path(a_plugin), (-1, mtime))
+                os.utime(self._full_path(a_plugin), (MIN_SAFE_TIMESTAMP, mtime))
         except TypeError:
             config_logger.error(
                 """

--- a/mlox/version.py
+++ b/mlox/version.py
@@ -3,7 +3,7 @@ import os
 import subprocess
 import sys
 import locale
-VERSION = "1.0.3"
+VERSION = "1.0.3 (with FAT32 fix)"
 
 
 def about():


### PR DESCRIPTION
A fix for FAT32 file system: -1 timestamp in os.utime() does not work on FAT32 file system (WinError 87) as the minimal timestamp is 01/01/1980 not 01/01/1970
More details in https://github.com/mlox/mlox/issues/57